### PR TITLE
Make getValue method protected to allow subclassing

### DIFF
--- a/easybatch-flatfile/src/main/java/org/easybatch/flatfile/DelimitedRecordMarshaller.java
+++ b/easybatch-flatfile/src/main/java/org/easybatch/flatfile/DelimitedRecordMarshaller.java
@@ -116,7 +116,7 @@ public class DelimitedRecordMarshaller extends AbstractRecordMarshaller {
         }
     }
 
-    private Object getValue(final String field, final Object object) throws InvocationTargetException, IllegalAccessException {
+    protected Object getValue(final String field, final Object object) throws InvocationTargetException, IllegalAccessException {
         return getters.get(field).invoke(object);
     }
 }

--- a/easybatch-integration/easybatch-apache-commons-csv/src/main/java/org/easybatch/integration/apache/common/csv/ApacheCommonCsvRecordMarshaller.java
+++ b/easybatch-integration/easybatch-apache-commons-csv/src/main/java/org/easybatch/integration/apache/common/csv/ApacheCommonCsvRecordMarshaller.java
@@ -90,7 +90,7 @@ public class ApacheCommonCsvRecordMarshaller extends AbstractRecordMarshaller {
         return result.substring(0, result.indexOf(recordSeparator));
     }
 
-    private Object getValue(final String field, final Object object) throws InvocationTargetException, IllegalAccessException {
+    protected Object getValue(final String field, final Object object) throws InvocationTargetException, IllegalAccessException {
         return getters.get(field).invoke(object);
     }
 }


### PR DESCRIPTION
This allow customization of values to output based on field name and record. 

Useful in my use case, because I have some fields that are domain object on which i want to return their id.

```java
ApacheCommonCsvRecordMarshaller marshaller = new ApacheCommonCsvRecordMarshaller(InteractionEntity.class, fields, csvFormat) {
    @Override
    protected Object getValue(String field, Object object) throws InvocationTargetException, IllegalAccessException {
        Object value = super.getValue(field, object);
        if (value instanceof ReferenceEntity) {
            return ((ReferenceEntity) value).getId();
        }
        return value;
    }
};
```