### PR TITLE
Add lineSeparator parameter to OutputStreamRecordWriter

### DIFF
--- a/easybatch-core/src/main/java/org/easybatch/core/writer/FileRecordWriter.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/writer/FileRecordWriter.java
@@ -47,6 +47,16 @@ public class FileRecordWriter extends OutputStreamRecordWriter {
     /**
      * Convenient processor that writes records to a file.
      *
+     * @param fileName the output file name.
+     * @param lineSeparator the line separator.
+     */
+    public FileRecordWriter(final String fileName, String lineSeparator) throws IOException {
+        super(new FileWriter(fileName), lineSeparator);
+    }
+
+    /**
+     * Convenient processor that writes records to a file.
+     *
      * @param file the output file.
      */
     public FileRecordWriter(final File file) throws IOException {
@@ -56,9 +66,29 @@ public class FileRecordWriter extends OutputStreamRecordWriter {
     /**
      * Convenient processor that writes records to a file.
      *
+     * @param file the output file.
+     * @param lineSeparator the line separator.
+     */
+    public FileRecordWriter(final File file, String lineSeparator) throws IOException {
+        super(new FileWriter(file), lineSeparator);
+    }
+
+    /**
+     * Convenient processor that writes records to a file.
+     *
      * @param fileWriter the output file writer.
      */
     public FileRecordWriter(final FileWriter fileWriter) throws IOException {
         super(fileWriter);
+    }
+
+    /**
+     * Convenient processor that writes records to a file.
+     *
+     * @param fileWriter the output file writer.
+     * @param lineSeparator the line separator.
+     */
+    public FileRecordWriter(final FileWriter fileWriter, String lineSeparator) throws IOException {
+        super(fileWriter, lineSeparator);
     }
 }

--- a/easybatch-core/src/main/java/org/easybatch/core/writer/OutputStreamRecordWriter.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/writer/OutputStreamRecordWriter.java
@@ -43,6 +43,8 @@ import static org.easybatch.core.util.Utils.*;
  */
 public class OutputStreamRecordWriter extends AbstractRecordWriter {
 
+    private String lineSeparator;
+
     private OutputStreamWriter outputStreamWriter;
 
     /**
@@ -54,15 +56,30 @@ public class OutputStreamRecordWriter extends AbstractRecordWriter {
      * @param outputStreamWriter the output stream to write records to.
      */
     public OutputStreamRecordWriter(OutputStreamWriter outputStreamWriter) {
+        this(outputStreamWriter, LINE_SEPARATOR);
+    }
+
+    /**
+     * Convenient processor to write the <strong>payload</strong> of a {@link Record} to an output stream.
+     * <p/>
+     * The user of this class is responsible for opening/closing the output stream, maybe using
+     * a {@link org.easybatch.core.api.event.job.JobEventListener}.
+     *
+     * @param outputStreamWriter the output stream to write records to.
+     * @param lineSeparator the line separator.
+     */
+    public OutputStreamRecordWriter(OutputStreamWriter outputStreamWriter, String lineSeparator) {
         checkNotNull(outputStreamWriter, "output stream writer");
         this.outputStreamWriter = outputStreamWriter;
+        this.lineSeparator = lineSeparator;
     }
 
     @Override
     public void writeRecord(final Object record) throws RecordProcessingException {
         Object payload = isRecord(record) ? ((Record) record).getPayload() : record;
         try {
-            outputStreamWriter.write(payload + LINE_SEPARATOR);
+            outputStreamWriter.write(payload.toString());
+            outputStreamWriter.write(lineSeparator);
             outputStreamWriter.flush();
         } catch (IOException exception) {
             String message = format("Unable to write record %s to the output stream writer", record);

--- a/easybatch-core/src/main/java/org/easybatch/core/writer/StandardOutputRecordWriter.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/writer/StandardOutputRecordWriter.java
@@ -42,4 +42,13 @@ public class StandardOutputRecordWriter extends OutputStreamRecordWriter {
         super(new OutputStreamWriter(System.out));
     }
 
+    /**
+     * Convenient processor that writes the <strong>payload</strong> of a {@link Record} to the standard output.
+     *
+     * @param lineSeparator line separator.
+     */
+    public StandardOutputRecordWriter(String lineSeparator) {
+        super(new OutputStreamWriter(System.out), lineSeparator);
+    }
+
 }

--- a/easybatch-core/src/test/java/org/easybatch/core/writer/OutputStreamRecordWriterTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/writer/OutputStreamRecordWriterTest.java
@@ -75,7 +75,8 @@ public class OutputStreamRecordWriterTest {
     public void testProcessRecord() throws Exception {
         outputStreamRecordWriter.processRecord(stringRecord);
 
-        verify(outputStreamWriter).write(PAYLOAD + LINE_SEPARATOR);
+        verify(outputStreamWriter).write(PAYLOAD);
+        verify(outputStreamWriter).write(LINE_SEPARATOR);
         verify(outputStreamWriter).flush();
     }
 


### PR DESCRIPTION
This is required to control the format of EOL (linux, mac or windows).