### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/easybatch-core/src/test/java/org/easybatch/core/mapper/ObjectMapperTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/mapper/ObjectMapperTest.java
@@ -45,7 +45,7 @@ public class ObjectMapperTest {
         ObjectMapper mapper = new ObjectMapper(Person.class);
 
         // input values
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new HashMap<>();
         values.put("firstName", "foo");
         values.put("lastName", "bar");
         values.put("age", "30");
@@ -71,7 +71,7 @@ public class ObjectMapperTest {
         ObjectMapper mapper = new ObjectMapper(ExtendedPerson.class);
 
         // input values
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new HashMap<>();
         values.put("firstName", "foo");
         values.put("lastName", "bar");
         values.put("age", "30");
@@ -105,7 +105,7 @@ public class ObjectMapperTest {
             }
         });
 
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new HashMap<>();
         values.put("gender", "MALE");
 
         Person person = (Person) mapper.mapObject(values);
@@ -118,7 +118,7 @@ public class ObjectMapperTest {
 
         ObjectMapper mapper = new ObjectMapper(Person.class);
 
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new HashMap<>();
         values.put("nickName", "foo");
 
         try {
@@ -134,7 +134,7 @@ public class ObjectMapperTest {
 
         ObjectMapper mapper = new ObjectMapper(Person.class);
 
-        Map<String, String> values = new HashMap<String, String>();
+        Map<String, String> values = new HashMap<>();
         values.put("age", null);
 
         Person person = (Person) mapper.mapObject(values);

--- a/easybatch-jdbc/src/test/java/org/easybatch/jdbc/JdbcRecordWriterTest.java
+++ b/easybatch-jdbc/src/test/java/org/easybatch/jdbc/JdbcRecordWriterTest.java
@@ -140,7 +140,7 @@ public class JdbcRecordWriterTest {
     }
 
     private List<Tweet> createTweets(Integer nbTweetsToInsert) {
-        List<Tweet> tweets = new ArrayList<Tweet>();
+        List<Tweet> tweets = new ArrayList<>();
         for (int i = 1; i <= nbTweetsToInsert; i++) {
             tweets.add(new Tweet(i, "user " + i, "hello " + i));
         }

--- a/easybatch-jpa/src/test/java/org/easybatch/jpa/JpaRecordReaderTest.java
+++ b/easybatch-jpa/src/test/java/org/easybatch/jpa/JpaRecordReaderTest.java
@@ -98,7 +98,7 @@ public class JpaRecordReaderTest {
     @Before
     public void setUp() throws Exception {
         String query = "from Tweet";
-        jpaRecordReader = new JpaRecordReader<Tweet>(entityManagerFactory, query, Tweet.class);
+        jpaRecordReader = new JpaRecordReader<>(entityManagerFactory, query, Tweet.class);
         jpaRecordReader.setFetchSize(FETCH_SIZE);
         jpaRecordReader.open();
     }

--- a/easybatch-xml/src/test/java/org/easybatch/xml/Dependency.java
+++ b/easybatch-xml/src/test/java/org/easybatch/xml/Dependency.java
@@ -296,7 +296,7 @@ public class Dependency {
          */
         public List<Exclusion> getExclusion() {
             if (exclusion == null) {
-                exclusion = new ArrayList<Exclusion>();
+                exclusion = new ArrayList<>();
             }
             return this.exclusion;
         }

--- a/easybatch-xml/src/test/java/org/easybatch/xml/XmlRecordMapperTest.java
+++ b/easybatch-xml/src/test/java/org/easybatch/xml/XmlRecordMapperTest.java
@@ -118,7 +118,7 @@ public class XmlRecordMapperTest {
     @Test(expected = RecordMappingException.class)
     public void testMappingWithUnescapedXmlSpecialCharacter() throws Exception {
         xmlRecord = new XmlRecord(header, "<website name='google' url='http://www.google.com?query=test&sort=asc'/>");
-        XmlRecordMapper<Website> xmlRecordMapper = new XmlRecordMapper<Website>(Website.class);
+        XmlRecordMapper<Website> xmlRecordMapper = new XmlRecordMapper<>(Website.class);
         xmlRecordMapper.processRecord(xmlRecord);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator (""<>"") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.