### PR TITLE
Replace inefficient keySet() Iterator with entrySet() and Use static parseXXX method instead of valueOf

### DIFF
--- a/easybatch-core/src/main/java/org/easybatch/core/converter/AtomicIntegerTypeConverter.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/converter/AtomicIntegerTypeConverter.java
@@ -43,7 +43,7 @@ public class AtomicIntegerTypeConverter implements TypeConverter<String, AtomicI
     public AtomicInteger convert(final String value) {
         checkArgument(value != null, "Value to convert must not be null");
         checkArgument(!value.isEmpty(), "Value to convert must not be empty");
-        return new AtomicInteger(Integer.valueOf(value));
+        return new AtomicInteger(Integer.parseInt(value));
     }
 
 }

--- a/easybatch-core/src/main/java/org/easybatch/core/converter/AtomicLongTypeConverter.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/converter/AtomicLongTypeConverter.java
@@ -43,7 +43,7 @@ public class AtomicLongTypeConverter implements TypeConverter<String, AtomicLong
     public AtomicLong convert(final String value) {
         checkArgument(value != null, "Value to convert must not be null");
         checkArgument(!value.isEmpty(), "Value to convert must not be empty");
-        return new AtomicLong(Long.valueOf(value));
+        return new AtomicLong(Long.parseLong(value));
     }
 
 }

--- a/easybatch-core/src/main/java/org/easybatch/core/dispatcher/ContentBasedRecordDispatcher.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/dispatcher/ContentBasedRecordDispatcher.java
@@ -68,7 +68,8 @@ public class ContentBasedRecordDispatcher<T extends Record> extends AbstractReco
             return;
         }
 
-        for (Predicate<T> predicate : queueMap.keySet()) {
+        for (Map.Entry<Predicate<T>, BlockingQueue<T>> entry : queueMap.entrySet()) {
+            Predicate<T> predicate = entry.getKey();
             //check if the record meets a given predicate
             if (!(predicate instanceof DefaultPredicate) && predicate.matches(record)) {
                 //if so, put it in the mapped queue

--- a/easybatch-core/src/main/java/org/easybatch/core/mapper/ObjectMapper.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/mapper/ObjectMapper.java
@@ -94,8 +94,9 @@ public class ObjectMapper {
         Object result = createInstance();
 
         // for each field
-        for (String field : values.keySet()) {
+        for (Map.Entry<String, String> entry : values.entrySet()) {
 
+            String field = entry.getKey();
             //get field raw value
             String value = values.get(field);
 

--- a/easybatch-jms/src/main/java/org/easybatch/jms/ContentBasedJmsRecordDispatcher.java
+++ b/easybatch-jms/src/main/java/org/easybatch/jms/ContentBasedJmsRecordDispatcher.java
@@ -70,7 +70,8 @@ public class ContentBasedJmsRecordDispatcher extends AbstractRecordDispatcher<Jm
         }
 
         Message payload = record.getPayload();
-        for (Predicate<JmsRecord> predicate : queueMap.keySet()) {
+        for (Map.Entry<Predicate<JmsRecord>, QueueSender> entry : queueMap.entrySet()) {
+            Predicate<JmsRecord> predicate = entry.getKey();
             //check if the record meets a given predicate
             if (!(predicate instanceof DefaultPredicate) && predicate.matches(record)) {
                 //put it in the mapped queue


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Findbugs rules
WMI_WRONG_MAP_ITERATOR - “ makes inefficient use of keySet iterator instead of entrySet iterator ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR
And
BC_EQUALS_METHOD_SHOULD_WORK_FOR_ALL_OBJECTS - “ Boxing/unboxing to parse a primitive convert(String) ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#BC_EQUALS_METHOD_SHOULD_WORK_FOR_ALL_OBJECTS
Please let me know if you have any questions.
Ayman Abdelghany.