### PR TITLE
Close preparedStatement after its execution

### DIFF
--- a/easybatch-jdbc/src/main/java/org/easybatch/jdbc/JdbcRecordWriter.java
+++ b/easybatch-jdbc/src/main/java/org/easybatch/jdbc/JdbcRecordWriter.java
@@ -68,6 +68,7 @@ public class JdbcRecordWriter extends AbstractRecordWriter {
             PreparedStatement preparedStatement = connection.prepareStatement(query);
             preparedStatementProvider.prepareStatement(preparedStatement, record);
             preparedStatement.executeUpdate();
+            preparedStatement.close();
         } catch (SQLException e) {
             throw new RecordWritingException("Unable to write record " + record + " to database", e);
         }


### PR DESCRIPTION
You should think in closing preparedStatement after preparedStatement.executeUpdate() this will avoid too many opened coursors in a huge batch insert transaction.

I have to create an object wich only its responsability is close it preparedStatement after its execution. Does this should not be a good pratice already!?

Keep good job!